### PR TITLE
feat(packagejson): added option to allow packagejson field

### DIFF
--- a/example/lit-ts/package.json
+++ b/example/lit-ts/package.json
@@ -23,5 +23,6 @@
   "devDependencies": {
     "typescript": "^4.6.4",
     "vite": "^4.0.1"
-  }
+  },
+  "customElements": "dist/custom-elements.json"
 }

--- a/example/lit-ts/vite.config.ts
+++ b/example/lit-ts/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     VitePluginCustomElementsManifest({
       files: ['./src/my-element.ts'],
       lit: true,
+      packageJson: true,
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsup src/index.ts --dts --format cjs,esm",
     "dev": "npm run build -- --watch",
-    "test": "vitest",
+    "test": "vitest --no-watch",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "release": "node ./scripts/version",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Plugin } from 'vite';
-import { join } from 'path';
-import { writeFileSync, mkdirSync } from 'fs';
-import { addCustomElementsPropertyToPackageJson } from '@custom-elements-manifest/analyzer/src/utils/cli-helpers.js';
+import {
+  join, posix, relative, sep,
+} from 'path';
+import { writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { createManifest, CreateManifestOptions } from './create';
 
 export interface VitePluginCustomElementsManifestOptions extends CreateManifestOptions {
@@ -53,7 +54,13 @@ function VitePluginCustomElementsManifest({
       writeFileSync(path, JSON.stringify(manifest));
 
       if (packageJson) {
-        addCustomElementsPropertyToPackageJson(path);
+        const packageJsonPath = `${process.cwd()}${sep}package.json`;
+        const pkg = JSON.parse(readFileSync(packageJsonPath).toString());
+        const relativePath = relative(process.cwd(), path);
+
+        pkg.customElements = relativePath.split(sep).join(posix.sep);
+
+        writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
       }
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'vite';
 import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
+import { addCustomElementsPropertyToPackageJson } from '@custom-elements-manifest/analyzer/src/utils/cli-helpers.js';
 import { createManifest, CreateManifestOptions } from './create';
 
 export interface VitePluginCustomElementsManifestOptions extends CreateManifestOptions {
@@ -17,6 +18,11 @@ export interface VitePluginCustomElementsManifestOptions extends CreateManifestO
    */
   output?: string,
   /**
+   * Add the custom-elements-manifest field to the package.json.
+   * @default false
+   */
+  packageJson?: boolean,
+  /**
    * Register files which will be used to build the manifest.
    * @default []
    */
@@ -26,6 +32,7 @@ export interface VitePluginCustomElementsManifestOptions extends CreateManifestO
 function VitePluginCustomElementsManifest({
   endpoint = '/custom-elements.json',
   output = 'custom-elements.json',
+  packageJson = false,
   files = [],
   ...createManifestOptions
 }: VitePluginCustomElementsManifestOptions = {}): Plugin {
@@ -44,6 +51,10 @@ function VitePluginCustomElementsManifest({
 
       mkdirSync(dir, { recursive: true });
       writeFileSync(path, JSON.stringify(manifest));
+
+      if (packageJson) {
+        addCustomElementsPropertyToPackageJson(path);
+      }
     },
   };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { createServer, build } from 'vite';
-import { readFile, rm } from 'fs/promises';
+import { readFile, rm, writeFile } from 'fs/promises';
 import {
   afterAll,
   describe,
@@ -164,34 +164,35 @@ describe('#VitePluginCustomElementsManifest', () => {
       expect(superclass.name).to.equal('LitElement');
     });
 
-    // eslint-disable-next-line max-len
-    // it('should append "custom-elements" to package.json matching the manifest name', async () => {
-    //   await build({
-    //     logLevel: 'silent',
-    //     build: {
-    //       lib: {
-    //         entry: litElement,
-    //         formats: ['es'],
-    //       },
-    //       rollupOptions: {
-    //         external: /^lit/,
-    //       },
-    //     },
-    //     plugins: [
-    //       VitePluginCustomElementsManifest({
-    //         output: 'my-custom-name.json',
-    //         files: [litElement],
-    //         packageJson: true,
-    //         lit: true,
-    //       }),
-    //     ],
-    //   });
+    it('should append "custom-elements" path to package.json', async () => {
+      const pkg = await readFile('./package.json');
 
-    //   const file = await readFile(path.resolve(litElement, '../package.json'));
-    //   const packageJson = JSON.parse(file.toString());
-    //   const { customElements } = packageJson;
+      await build({
+        logLevel: 'silent',
+        build: {
+          lib: {
+            entry: litElement,
+            formats: ['es'],
+          },
+          rollupOptions: {
+            external: /^lit/,
+          },
+        },
+        plugins: [
+          VitePluginCustomElementsManifest({
+            output: 'my-custom-name.json',
+            files: [litElement],
+            packageJson: true,
+            lit: true,
+          }),
+        ],
+      });
 
-    //   expect(customElements).to.equal('./dist/my-custom-name.json');
-    // });
+      const file = await readFile('./package.json');
+      const { customElements } = JSON.parse(file.toString());
+
+      expect(customElements).to.equal('dist/my-custom-name.json');
+      writeFile('./package.json', pkg);
+    });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -163,5 +163,35 @@ describe('#VitePluginCustomElementsManifest', () => {
       expect(description).to.equal('An example element.');
       expect(superclass.name).to.equal('LitElement');
     });
+
+    // eslint-disable-next-line max-len
+    // it('should append "custom-elements" to package.json matching the manifest name', async () => {
+    //   await build({
+    //     logLevel: 'silent',
+    //     build: {
+    //       lib: {
+    //         entry: litElement,
+    //         formats: ['es'],
+    //       },
+    //       rollupOptions: {
+    //         external: /^lit/,
+    //       },
+    //     },
+    //     plugins: [
+    //       VitePluginCustomElementsManifest({
+    //         output: 'my-custom-name.json',
+    //         files: [litElement],
+    //         packageJson: true,
+    //         lit: true,
+    //       }),
+    //     ],
+    //   });
+
+    //   const file = await readFile(path.resolve(litElement, '../package.json'));
+    //   const packageJson = JSON.parse(file.toString());
+    //   const { customElements } = packageJson;
+
+    //   expect(customElements).to.equal('./dist/my-custom-name.json');
+    // });
   });
 });


### PR DESCRIPTION
Using the cli-helpers utility from `@custom-elements-manifest/analyzer` I provided an option with a false default to the plugin using the function that adds the `custom-elements` property to the `package.json`.

fixes #3 